### PR TITLE
Implement StyleCop.Analyzers and clean up code accordingly

### DIFF
--- a/AdvanceDLSupport.sln
+++ b/AdvanceDLSupport.sln
@@ -4,6 +4,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "metadata", ".\", "{F1A57014
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		README.md = README.md
+		stylecop.json = stylecop.json
+		stylecop.ruleset = stylecop.ruleset
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvancedDLSupport", "AdvancedDLSupport\AdvancedDLSupport.csproj", "{7EDC8F84-DF28-4C3C-AF56-F283B694218A}"

--- a/AdvancedDLSupport.Example/AdvancedDLSupport.Example.csproj
+++ b/AdvancedDLSupport.Example/AdvancedDLSupport.Example.csproj
@@ -2,9 +2,25 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(ProjectDir)\..\stylecop.json">
+      <Link>stylecop.json</Link>
+      <InProject>false</InProject>
+    </AdditionalFiles>
+    <AdditionalFiles Include="$(ProjectDir)\..\stylecop.ruleset">
+      <Link>stylecop.ruleset</Link>
+      <InProject>false</InProject>
+    </AdditionalFiles>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\AdvancedDLSupport\AdvancedDLSupport.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
   </ItemGroup>
   <Target Name="CompileCProject" AfterTargets="AfterBuild">
     <exec Command="clang -std=c99 -shared -fPIC -oc\libDemo.so c\src\Example.c" />

--- a/AdvancedDLSupport.Example/IExample.cs
+++ b/AdvancedDLSupport.Example/IExample.cs
@@ -1,0 +1,9 @@
+﻿#pragma warning disable SA1600, CS1591 // Elements should be documented
+
+namespace AdvancedDLSupport.Example
+{
+    public interface IExample
+    {
+        int DoMath(ref MyStruct struc);
+    }
+}

--- a/AdvancedDLSupport.Example/MyStruct.cs
+++ b/AdvancedDLSupport.Example/MyStruct.cs
@@ -1,0 +1,9 @@
+﻿#pragma warning disable SA1600, CS1591 // Elements should be documented
+
+namespace AdvancedDLSupport.Example
+{
+    public struct MyStruct
+    {
+        public int A;
+    }
+}

--- a/AdvancedDLSupport.Example/Program.cs
+++ b/AdvancedDLSupport.Example/Program.cs
@@ -1,21 +1,14 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
-namespace AdvancedDLSupport
+#pragma warning disable SA1600, CS1591 // Elements should be documented
+
+namespace AdvancedDLSupport.Example
 {
-    public struct MyStruct
+    internal class Program
     {
-        public int A;
-    }
-    public interface IExample
-    {
-        int DoMath(ref MyStruct struc);
-    }
-    class Program
-    {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             IExample wrapper;
             try
@@ -28,7 +21,12 @@ namespace AdvancedDLSupport
                 throw e;
             }
             Console.WriteLine("Wrapper loaded!");
-            var field = wrapper.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetField).First(I => I.Name == "DoMath_dtm");
+            var field = wrapper.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetField)
+            .First
+            (
+                f => f.Name == "DoMath_dtm"
+            );
+
             var val = field.GetValue(wrapper);
             if (val == null)
             {
@@ -38,7 +36,8 @@ namespace AdvancedDLSupport
             {
                 Console.WriteLine("DoMath_dtm is not null!");
             }
-            var struc = new MyStruct{A = 22};
+
+            var struc = new MyStruct { A = 22 };
             Console.WriteLine("{0}", wrapper.DoMath(ref struc));
         }
     }

--- a/AdvancedDLSupport/AdvancedDLSupport.csproj
+++ b/AdvancedDLSupport/AdvancedDLSupport.csproj
@@ -1,8 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(ProjectDir)\..\stylecop.json">
+      <Link>stylecop.json</Link>
+      <InProject>false</InProject>
+    </AdditionalFiles>
+    <AdditionalFiles Include="$(ProjectDir)\..\stylecop.ruleset">
+      <Link>stylecop.ruleset</Link>
+      <InProject>false</InProject>
+    </AdditionalFiles>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/AdvancedDLSupport/DLSupport.cs
+++ b/AdvancedDLSupport/DLSupport.cs
@@ -1,40 +1,49 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
-using System.Linq;
+
+#pragma warning disable SA1600, CS1591 // Elements should be documented
+#pragma warning disable SA1300 // Element should begin with an uppercase letter
+
 public class DLSupport
 {
-    static ModuleBuilder moduleBuilder;
-    static AssemblyBuilder assemblyBuilder;
+    private static ModuleBuilder moduleBuilder;
+    private static AssemblyBuilder assemblyBuilder;
+
     static DLSupport()
     {
         IsOnWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
         assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DLSupportAssembly"), AssemblyBuilderAccess.Run);
         moduleBuilder = assemblyBuilder.DefineDynamicModule("DLSupportModule");
     }
-    static bool IsOnWindows;
+
+    private static bool IsOnWindows;
 
     [DllImport("dl")]
-    static extern IntPtr dlopen(string path, int flag = 1);
+    private static extern IntPtr dlopen(string path, int flag = 1);
+
     [DllImport("dl")]
-    static extern IntPtr dlsym(IntPtr handle, string symbol);
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
     [DllImport("dl")]
-    static extern int dlclose(IntPtr handle);
+    private static extern int dlclose(IntPtr handle);
+
     [DllImport("dl")]
-    static extern IntPtr dlerror();
+    private static extern IntPtr dlerror();
 
     [DllImport("kernel32.dll")]
-    static extern IntPtr LoadLibrary(string path);
+    private static extern IntPtr LoadLibrary(string path);
 
     [DllImport("kernel32.dll")]
-    static extern IntPtr GetProcAddress(IntPtr handle, string symbol);
+    private static extern IntPtr GetProcAddress(IntPtr handle, string symbol);
 
     [DllImport("kernel32.dll")]
-    static extern bool FreeLibrary(IntPtr handle);
+    private static extern bool FreeLibrary(IntPtr handle);
 
-    private IntPtr libraryHandle {get;set;}
+    private IntPtr libraryHandle { get; set; }
 
     public DLSupport(string path)
     {
@@ -42,7 +51,9 @@ public class DLSupport
         {
             libraryHandle = LoadLibrary(path);
             if (libraryHandle == IntPtr.Zero)
+            {
                 throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
         }
         else
         {
@@ -51,16 +62,21 @@ public class DLSupport
             {
                 var errorPtr = dlerror();
                 if (errorPtr == IntPtr.Zero)
+                {
                     throw new Exception("Library could not be loaded and error information from dl library could not be found...");
+                }
+
                 var msg = Marshal.PtrToStringAuto(errorPtr);
                 throw new Exception(string.Format("Library could not be loaded: {0}", msg));
             }
         }
     }
+
     public IntPtr LoadSymbol(string sym) =>
         IsOnWindows ? GetProcAddress(libraryHandle, sym) : dlsym(libraryHandle, sym);
 
-    public T LoadFunction<T>(string sym) {
+    public T LoadFunction<T>(string sym)
+    {
         var symPointer = LoadSymbol(sym);
         return Marshal.GetDelegateForFunctionPointer<T>(symPointer);
     }
@@ -74,74 +90,109 @@ public class DLSupport
     public void UnsafeDispose()
     {
         if (IsOnWindows)
+        {
             FreeLibrary(libraryHandle);
+        }
         else
+        {
             dlclose(libraryHandle);
+        }
     }
 
-    static bool IsMethodAcceptable(MethodInfo info)
+    private static bool IsMethodAcceptable(MethodInfo info)
     {
         return !info.ReturnParameter.ParameterType.IsClass &&
-                !info.GetParameters().Any(I => I.ParameterType.IsClass);
+               !info.GetParameters().Any(p => p.ParameterType.IsClass);
     }
 
     /// <summary>
     /// Attempts to resolve interface to C Library via C# Interface by dynamically creating C# Class during runtime
     /// and return a new instance of the said class. This approach does not resolve any C++ implication such as name manglings.
     /// </summary>
+    /// <param name="libraryPath">The path to the library.</param>
+    /// <typeparam name="T">The interface type to map to.</typeparam>
+    /// <returns>A generated object that implements <typeparamref name="T"/>.</returns>
     public static T ResolveAndActivateInterface<T>(string libraryPath)
     {
         var type = typeof(T);
-        if (!type.IsInterface) throw new Exception("The generic argument type must be an interface! Please review the documentation on how to use this.");
+        if (!type.IsInterface)
+        {
+            throw new Exception("The generic argument type must be an interface! Please review the documentation on how to use this.");
+        }
 
         // Let's determine a name for our class!
         string typeName;
         if (type.Name.StartsWith("I"))
+        {
             typeName = type.Name.Substring(1);
+        }
         else
+        {
             typeName = $"Generated_{type.Name}";
+        }
 
         if (string.IsNullOrWhiteSpace(typeName))
+        {
             typeName = $"Generated_{type.Name}";
+        }
 
-        //typeName = $"{typeName}{Guid.NewGuid().ToString().Replace("-", "_")}";
         // Let's create a new type!
-        var typeBuilder = moduleBuilder.DefineType(typeName,
+        var typeBuilder = moduleBuilder.DefineType
+        (
+            typeName,
             TypeAttributes.AutoClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
-            typeof(DLSupport), new [] {type});
+            typeof(DLSupport),
+            new[] { type }
+        );
 
-                // Now the constructor
-        var constructorBuilder = typeBuilder.DefineConstructor(
+        // Now the constructor
+        var constructorBuilder = typeBuilder.DefineConstructor
+        (
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
-            CallingConventions.Standard, new [] {typeof(string)});
+            CallingConventions.Standard,
+            new[] { typeof(string) }
+        );
 
         constructorBuilder.DefineParameter(1, ParameterAttributes.In, "libraryPath");
         var il = constructorBuilder.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0); // Load instance
         il.Emit(OpCodes.Ldarg_1); // Load libraryPath parameter
-        il.Emit(OpCodes.Call, typeof(DLSupport).GetConstructors().First(I =>
-            I.GetParameters().Length == 1 &&
-            I.GetParameters()[0].ParameterType == typeof(string)));
+        il.Emit(OpCodes.Call, typeof(DLSupport).GetConstructors().First
+        (
+            c =>
+                c.GetParameters().Length == 1 &&
+                c.GetParameters()[0].ParameterType == typeof(string))
+        );
+
         // Let's define our methods!
         foreach (var method in type.GetMethods())
         {
             var parameters = method.GetParameters();
 
             // Declare a delegate type!
-            var delegateBuilder = moduleBuilder.DefineType($"{method.Name}_dt",
-                                                    TypeAttributes.Class | TypeAttributes.Public |
-                                                    TypeAttributes.Sealed | TypeAttributes.AnsiClass |
-                                                    TypeAttributes.AutoClass, typeof(MulticastDelegate));
+            var delegateBuilder = moduleBuilder.DefineType
+            (
+                $"{method.Name}_dt",
+                TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass,
+                typeof(MulticastDelegate)
+            );
 
-            ConstructorBuilder delegateCtorBuilder = delegateBuilder.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig |
-                                                                                  MethodAttributes.Public, CallingConventions.Standard,
-                                                                                  new Type[] { typeof(object), typeof(System.IntPtr) });
+            var delegateCtorBuilder = delegateBuilder.DefineConstructor
+            (
+                MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
+                CallingConventions.Standard,
+                new[] { typeof(object), typeof(System.IntPtr) }
+            );
 
             delegateCtorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
 
-            var delegateMethodBuilder = delegateBuilder.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig |
-                                                                   MethodAttributes.NewSlot | MethodAttributes.Virtual,
-                                                                   method.ReturnType, parameters.Select(I => I.ParameterType).ToArray());
+            var delegateMethodBuilder = delegateBuilder.DefineMethod
+            (
+                "Invoke",
+                MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,
+                method.ReturnType,
+                parameters.Select(p => p.ParameterType).ToArray()
+            );
 
             delegateMethodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
 
@@ -149,18 +200,24 @@ public class DLSupport
 
             // Create a delegate property!
             var delegateField = typeBuilder.DefineField($"{method.Name}_dtm", delegateBuilderType, FieldAttributes.Public);
-            var methodBuilder = typeBuilder.DefineMethod(method.Name,
+            var methodBuilder = typeBuilder.DefineMethod
+            (
+                method.Name,
                 MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
                 System.Reflection.CallingConventions.Standard,
                 method.ReturnType,
-                parameters.Select(I => I.ParameterType).ToArray());
+                parameters.Select(p => p.ParameterType).ToArray()
+            );
 
             // Let's create a method that simply invoke the delegate
             var methodIL = methodBuilder.GetILGenerator();
             methodIL.Emit(OpCodes.Ldarg_0);
             methodIL.Emit(OpCodes.Ldfld, delegateField);
-            for (int I = 1; I <= parameters.Length; I++)
-                methodIL.Emit(OpCodes.Ldarg, I);
+            for (int i = 1; i <= parameters.Length; i++)
+            {
+                methodIL.Emit(OpCodes.Ldarg, i);
+            }
+
             methodIL.EmitCall(OpCodes.Call, delegateBuilderType.GetMethod("Invoke"), null);
             methodIL.Emit(OpCodes.Ret);
 
@@ -171,18 +228,18 @@ public class DLSupport
             il.EmitCall(OpCodes.Call, typeof(DLSupport).GetMethod("LoadFunction").MakeGenericMethod(delegateBuilderType), null);
             il.Emit(OpCodes.Stfld, delegateField);
         }
+
         foreach (var property in type.GetProperties())
         {
             if (property.CanRead)
             {
-
             }
 
             if (property.CanWrite)
             {
-
             }
         }
+
         il.Emit(OpCodes.Ret);
         return (T)Activator.CreateInstance(typeBuilder.CreateTypeInfo(), libraryPath);
     }

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,61 @@
+{
+    "$schema" : "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+    "settings" : {
+        "indentation" : {
+            "indentationSize" : 4,
+            "tabSize" : 4,
+            "useTabs" : false
+        },
+        "spacingRules" : {
+        },
+        "readabilityRules" : {
+        },
+        "orderingRules" : {
+            "elementOrder" : [
+                "kind",
+                "constant",
+                "accessibility",
+                "static",
+                "readonly"
+            ],
+            "systemUsingDirectivesFirst" : true,
+            "usingDirectivesPlacement" : "outsideNamespace",
+            "blankLinesBetweenUsingGroups" : "allow"
+        },
+        "namingRules" : {
+            "allowCommonHungarianPrefixes" : true,
+            "allowedHungarianPrefixes" : [
+                "gl"
+            ]
+        },
+        "maintainabilityRules" : {
+            "topLevelTypes" : [
+                "class",
+                "interface",
+                "struct",
+                "enum"
+            ]
+        },
+        "layoutRules" : {
+            "newlineAtEndOfFile" : "require",
+            "allowConsecutiveUsings" : false
+        },
+        "documentationRules" : {
+            "companyName" : "",
+            "copyrightText" : "",
+            "variables" : {
+                "licenseFile": "LICENSE",
+                "year" : "2017",
+                "author" : ""
+            },
+            "xmlHeader" : false,
+            "documentInterfaces" : true,
+            "documentExposedElements" : true,
+            "documentInternalElements" : true,
+            "documentPrivateElements" : false,
+            "documentPrivateFields" : false,
+            "documentationCulture" : "en-US",
+            "fileNamingConvention" : "stylecop"
+        }
+    }
+}

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -1,0 +1,199 @@
+<RuleSet Name="Complete StyleCop Rules" ToolsVersion="12.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+
+    <!-- Special rules -->
+    <Rule Id="SA0001" Action="Error" /> <!-- XML comment analysis disabled -->
+    <Rule Id="SA0002" Action="Error" /> <!-- Invalid settings file -->
+
+    <!-- Spacing rules -->
+    <Rule Id="SA1000" Action="Error" /> <!-- Keywords must be spaced correctly -->
+    <Rule Id="SA1001" Action="Error" /> <!-- Commas must be spaced correctly -->
+    <Rule Id="SA1002" Action="Error" /> <!-- Semicolons must be spaced correctly -->
+    <Rule Id="SA1003" Action="Error" /> <!-- Symbols must be spaced correctly -->
+    <Rule Id="SA1004" Action="Error" /> <!-- Documentation lines must begin with single space -->
+    <Rule Id="SA1005" Action="Warning" Intentional="true" Reason="Used for quick debugging"/> <!-- Single line comments must begin with single space -->
+    <Rule Id="SA1006" Action="Error" /> <!-- Preprocessor keywords must not be preceded by space -->
+    <Rule Id="SA1007" Action="Error" /> <!-- Operator keyword must be followed by space -->
+    <Rule Id="SA1008" Action="Error" /> <!-- Opening parenthesis must be spaced correctly -->
+    <Rule Id="SA1009" Action="None" Intentional="true" Reason="Used for alignment"/> <!-- Closing parenthesis must be spaced correctly -->
+    <Rule Id="SA1010" Action="Error" /> <!-- Opening square brackets must be spaced correctly -->
+    <Rule Id="SA1011" Action="Error" /> <!-- Closing square brackets must be spaced correctly -->
+    <Rule Id="SA1012" Action="Error" /> <!-- Opening braces must be spaced correctly -->
+    <Rule Id="SA1013" Action="Error" /> <!-- Closing braces must be spaced correctly -->
+    <Rule Id="SA1014" Action="Error" /> <!-- Opening generic brackets must be spaced correctly -->
+    <Rule Id="SA1015" Action="Error" /> <!-- Closing generic brackets must be spaced correctly -->
+    <Rule Id="SA1016" Action="Error" /> <!-- Opening attribute brackets must be spaced correctly -->
+    <Rule Id="SA1017" Action="Error" /> <!-- Closing attribute brackets must be spaced correctly -->
+    <Rule Id="SA1018" Action="Error" /> <!-- Nullable type symbols must be spaced correctly -->
+    <Rule Id="SA1019" Action="Error" /> <!-- Member access symbols must be spaced correctly -->
+    <Rule Id="SA1020" Action="Error" /> <!-- Increment decrement symbols must be spaced correctly -->
+    <Rule Id="SA1021" Action="Error" /> <!-- Negative signs must be spaced correctly -->
+    <Rule Id="SA1022" Action="Error" /> <!-- Positive signs must be spaced correctly -->
+    <Rule Id="SA1023" Action="Error" /> <!-- Dereference and access of symbols must be spaced correctly -->
+    <Rule Id="SA1024" Action="Error" /> <!-- Colons must be spaced correctly -->
+    <Rule Id="SA1025" Action="Error" /> <!-- Code must not contain multiple whitespace in a row -->
+    <Rule Id="SA1026" Action="Error" /> <!-- Code must not contain space after new keyword in implicitly typed array allocation -->
+    <Rule Id="SA1027" Action="Error" /> <!-- Use tabs correctly -->
+    <Rule Id="SA1028" Action="Error" /> <!-- Code must not contain trailing whitespace -->
+
+    <!-- Readability rules -->
+    <Rule Id="SA1100" Action="Error" /> <!-- Do not prefix calls with base unless local implementation exists -->
+    <Rule Id="SA1101" Action="None"/> <!-- Prefix local calls with this -->
+    <Rule Id="SX1101" Action="None" Intentional="true" /> <!-- Do not prefix local calls with this. -->
+    <Rule Id="SA1102" Action="Error" /> <!-- Query clause must follow previous clause -->
+    <Rule Id="SA1103" Action="Error" /> <!-- Query clauses must be on separate lines or all on one line -->
+    <Rule Id="SA1104" Action="Error" /> <!-- Query clause must begin on new line when previous clause spans multiple lines -->
+    <Rule Id="SA1105" Action="Error" /> <!-- Query clauses spanning multiple lines must begin on own line -->
+    <Rule Id="SA1106" Action="Error" /> <!-- Code must not contain empty statements -->
+    <Rule Id="SA1107" Action="Error" /> <!-- Code must not contain multiple statements on one line -->
+    <Rule Id="SA1108" Action="Error" /> <!-- Block statements must not contain embedded comments -->
+    <Rule Id="SA1110" Action="None" Intentional="true" /> <!-- Opening parenthesis or bracket must be on declaration line -->
+    <Rule Id="SA1111" Action="None" Intentional="true" /> <!-- Closing parenthesis must be on line of last parameter -->
+    <Rule Id="SA1112" Action="Error" /> <!-- Closing parenthesis must be on line of opening parenthesis -->
+    <Rule Id="SA1113" Action="Error" /> <!-- Comma must be on the same line as previous parameter -->
+    <Rule Id="SA1114" Action="Error" /> <!-- Parameter list must follow declaration -->
+    <Rule Id="SA1115" Action="Error" /> <!-- Parameter must follow comma -->
+    <Rule Id="SA1116" Action="Error" /> <!-- Split parameters must start on line after declaration -->
+    <Rule Id="SA1117" Action="Error" /> <!-- Parameters must be on same line or separate lines -->
+    <Rule Id="SA1118" Action="Error" /> <!-- Parameter must not span multiple lines -->
+    <Rule Id="SA1119" Action="Error" /> <!-- Statement must not use unnecessary parenthesis -->
+    <Rule Id="SA1120" Action="None" Intentional="true" Reason="Used for spacing in license header"/> <!-- Comments must contain text -->
+    <Rule Id="SA1121" Action="Error" /> <!-- Use built-in type alias -->
+    <Rule Id="SA1122" Action="Error" /> <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1123" Action="Error" /> <!-- Do not place regions within elements -->
+    <Rule Id="SA1124" Action="Error" /> <!-- Do not use regions -->
+    <Rule Id="SA1125" Action="Error" /> <!-- Use shorthand for nullable types -->
+    <Rule Id="SA1127" Action="None" Intentional="true" /> <!-- Generic type constraints must be on their own line -->
+    <Rule Id="SA1128" Action="Error" /> <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1129" Action="Error" /> <!-- Do not use default value type constructor -->
+    <Rule Id="SA1130" Action="Error" /> <!-- Use lambda syntax -->
+    <Rule Id="SA1131" Action="Error" /> <!-- Use readable conditions -->
+    <Rule Id="SA1132" Action="Error" /> <!-- Do not combine fields -->
+    <Rule Id="SA1133" Action="None" Intentional="true" /> <!-- Do not combine attributes -->
+    <Rule Id="SA1134" Action="Error" /> <!-- Attributes must not share line -->
+    <Rule Id="SA1136" Action="Error" /> <!-- Enum values should be on separate lines -->
+    <Rule Id="SA1137" Action="Error" /> <!-- Elements should have the same indentation -->
+    <Rule Id="SA1139" Action="Error" /> <!-- Use literals suffix notation instead of casting -->
+
+    <!-- Ordering rules -->
+    <Rule Id="SA1200" Action="Error" /> <!-- Using directives must be placed correctly -->
+    <Rule Id="SA1201" Action="None" Intentional="true" /> <!-- Elements must appear in the correct order -->
+    <Rule Id="SA1202" Action="None" Intentional="true" /> <!-- Elements must be ordered by access -->
+    <Rule Id="SA1203" Action="Error" /> <!-- Constants must appear before fields -->
+    <Rule Id="SA1204" Action="None" Intentional="true" /> <!-- Static elements must appear before instance elements -->
+    <Rule Id="SA1205" Action="Error" /> <!-- Partial elements must declare access -->
+    <Rule Id="SA1206" Action="Error" /> <!-- Declaration keywords must follow order -->
+    <Rule Id="SA1207" Action="Error" /> <!-- Protected must come before internal -->
+    <Rule Id="SA1208" Action="Error" /> <!-- System using directives must be placed before other using directives -->
+    <Rule Id="SA1209" Action="Error" /> <!-- Using alias directives must be placed after other using directives -->
+    <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
+    <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
+    <Rule Id="SA1211" Action="Error" /> <!-- Using alias directives must be ordered alphabetically by alias name -->
+    <Rule Id="SA1212" Action="Error" /> <!-- Property accessors must follow order -->
+    <Rule Id="SA1213" Action="Error" /> <!-- Event accessors must follow order -->
+    <Rule Id="SA1214" Action="Error" /> <!-- Readonly fields must appear before non-readonly fields -->
+    <Rule Id="SA1216" Action="Error" /> <!-- Using static directives must be placed at the correct location. -->
+    <Rule Id="SA1217" Action="Error" /> <!-- Using static directives must be ordered alphabetically -->
+
+    <!-- Naming rules -->
+    <Rule Id="SA1300" Action="Error" /> <!-- Element must begin with upper-case letter -->
+    <Rule Id="SA1302" Action="Error" /> <!-- Interface names must begin with I -->
+    <Rule Id="SA1303" Action="Error" /> <!-- Const field names must begin with upper-case letter -->
+    <Rule Id="SA1304" Action="Error" /> <!-- Non-private readonly fields must begin with upper-case letter -->
+    <Rule Id="SA1305" Action="Error" /> <!-- Field names must not use Hungarian notation -->
+    <Rule Id="SA1306" Action="None" Intentional="true" Reason="Field names should begin with upper-case latter"/> <!-- Field names must begin with lower-case letter -->
+    <Rule Id="SA1307" Action="Error" /> <!-- Accessible fields must begin with upper-case letter -->
+    <Rule Id="SA1308" Action="Error" /> <!-- Variable names must not be prefixed -->
+    <Rule Id="SA1309" Action="Error" /> <!-- Field names must not begin with underscore -->
+    <Rule Id="SX1309" Action="None" Intentional="true" /> <!-- Field names must begin with underscore -->
+    <Rule Id="SX1309S" Action="None" Intentional="true" /> <!-- Static field names must begin with underscore -->
+    <Rule Id="SA1310" Action="Error" /> <!-- Field names must not contain underscore -->
+    <Rule Id="SA1311" Action="Error" /> <!-- Static readonly fields must begin with upper-case letter -->
+    <Rule Id="SA1312" Action="Error" /> <!-- Variable names must begin with lower-case letter -->
+    <Rule Id="SA1313" Action="Error" /> <!-- Parameter names must begin with lower-case letter -->
+    <Rule Id="SA1314" Action="Error" /> <!-- Type name parameters must begin with T -->
+
+    <!-- Maintainability rules -->
+    <Rule Id="SA1400" Action="Error" /> <!-- Access modifier must be declared -->
+    <Rule Id="SA1401" Action="Error" /> <!-- Fields must be private -->
+    <Rule Id="SA1402" Action="Error" /> <!-- File may only contain a single class -->
+    <Rule Id="SA1403" Action="Error" /> <!-- File may only contain a single namespace -->
+    <Rule Id="SA1404" Action="Error" /> <!-- Code analysis suppression must have justification -->
+    <Rule Id="SA1405" Action="Error" /> <!-- Debug.Assert must provide message text -->
+    <Rule Id="SA1406" Action="Error" /> <!-- Debug.Fail must provide message text -->
+    <Rule Id="SA1407" Action="Error" /> <!-- Arithmetic expressions must declare precedence -->
+    <Rule Id="SA1408" Action="Error" /> <!-- Conditional expressions must declare precedence -->
+    <Rule Id="SA1410" Action="Error" /> <!-- Remove delegate parenthesis when possible -->
+    <Rule Id="SA1411" Action="Error" /> <!-- Attribute constructor must not use unnecessary parenthesis -->
+    <Rule Id="SA1412" Action="None" Intentional="true" /> <!-- Store files as UTF-8 with byte order mark -->
+    <Rule Id="SA1413" Action="None" Intentional="true" /> <!-- Use trailing comma in multi-line initializers -->
+
+    <!-- Layout rules -->
+    <Rule Id="SA1500" Action="Error" /> <!-- Braces for multi-line statements must not share line -->
+    <Rule Id="SA1501" Action="Error" /> <!-- Statement must not be on a single line -->
+    <Rule Id="SA1502" Action="Error" /> <!-- Element must not be on a single line -->
+    <Rule Id="SA1503" Action="Error" /> <!-- Braces must not be omitted -->
+    <Rule Id="SA1504" Action="Error" /> <!-- All accessors must be single-line or multi-line -->
+    <Rule Id="SA1505" Action="Error" /> <!-- Opening braces must not be followed by blank line -->
+    <Rule Id="SA1506" Action="Error" /> <!-- Element documentation headers must not be followed by blank line -->
+    <Rule Id="SA1507" Action="Error" /> <!-- Code must not contain multiple blank lines in a row -->
+    <Rule Id="SA1508" Action="Error" /> <!-- Closing braces must not be preceded by blank line -->
+    <Rule Id="SA1509" Action="Error" /> <!-- Opening braces must not be preceded by blank line -->
+    <Rule Id="SA1510" Action="Error" /> <!-- Chained statement blocks must not be preceded by blank line -->
+    <Rule Id="SA1511" Action="Error" /> <!-- While-do footer must not be preceded by blank line -->
+    <Rule Id="SA1512" Action="Warning" Intentional="true" Reason="Used for spacing"/> <!-- Single-line comments must not be followed by blank line -->
+    <Rule Id="SA1513" Action="None" Intentional="true" Reason="Waiting for configurable option for enums"/> <!-- Closing brace must be followed by blank line -->
+    <Rule Id="SA1514" Action="Error" /> <!-- Element documentation header must be preceded by blank line -->
+    <Rule Id="SA1515" Action="Warning" Intentional="true" Reason="Used for spacing"/> <!-- Single-line comment must be preceded by blank line -->
+    <Rule Id="SA1516" Action="Error" /> <!-- Elements must be separated by blank line -->
+    <Rule Id="SA1517" Action="Error" /> <!-- Code must not contain blank lines at start of file -->
+    <Rule Id="SA1518" Action="Error" /> <!-- Use line endings correctly at end of file -->
+    <Rule Id="SA1519" Action="Error" /> <!-- Braces must not be omitted from multi-line child statement -->
+    <Rule Id="SA1520" Action="Error" /> <!-- Use braces consistently -->
+
+    <!-- Documentation rules -->
+    <Rule Id="SA1600" Action="Error" /> <!-- Elements must be documented -->
+    <Rule Id="SA1601" Action="None" Intentional="true" /> <!-- Partial elements must be documented -->
+    <Rule Id="SA1602" Action="Error" /> <!-- Enumeration items must be documented -->
+    <Rule Id="SA1604" Action="Error" /> <!-- Element documentation must have summary -->
+    <Rule Id="SA1605" Action="Error" /> <!-- Partial element documentation must have summary -->
+    <Rule Id="SA1606" Action="Error" /> <!-- Element documentation must have summary text -->
+    <Rule Id="SA1607" Action="Error" /> <!-- Partial element documentation must have summary text -->
+    <Rule Id="SA1608" Action="Error" /> <!-- Element documentation must not have default summary -->
+    <Rule Id="SA1609" Action="None" Intentional="true" /> <!-- Property documentation must have value -->
+    <Rule Id="SA1610" Action="None" Intentional="true "/> <!-- Property documentation must have value text -->
+    <Rule Id="SA1611" Action="Error" /> <!-- Element parameters must be documented -->
+    <Rule Id="SA1612" Action="Error" /> <!-- Element parameter documentation must match element parameters -->
+    <Rule Id="SA1613" Action="Error" /> <!-- Element parameter documentation must declare parameter name -->
+    <Rule Id="SA1614" Action="Error" /> <!-- Element parameter documentation must have text -->
+    <Rule Id="SA1615" Action="Error" /> <!-- Element return value must be documented -->
+    <Rule Id="SA1616" Action="Error" /> <!-- Element return value documentation must have text -->
+    <Rule Id="SA1617" Action="Error" /> <!-- Void return value must not be documented -->
+    <Rule Id="SA1618" Action="Error" /> <!-- Generic type parameters must be documented -->
+    <Rule Id="SA1619" Action="Error" /> <!-- Generic type parameters must be documented partial class -->
+    <Rule Id="SA1620" Action="Error" /> <!-- Generic type parameter documentation must match type parameters -->
+    <Rule Id="SA1621" Action="Error" /> <!-- Generic type parameter documentation must declare parameter name -->
+    <Rule Id="SA1622" Action="Error" /> <!-- Generic type parameter documentation must have text -->
+    <Rule Id="SA1623" Action="Error" /> <!-- Property summary documentation must match accessors -->
+    <Rule Id="SA1624" Action="Error" /> <!-- Property summary documentation must omit accessor with restricted access -->
+    <Rule Id="SA1625" Action="Error" /> <!-- Element documentation must not be copied and pasted -->
+    <Rule Id="SA1626" Action="Error" /> <!-- Single-line comments must not use documentation style slashes -->
+    <Rule Id="SA1627" Action="Error" /> <!-- Documentation text must not be empty -->
+    <Rule Id="SA1629" Action="Error" /> <!-- Documentation text must end with a period -->
+    <Rule Id="SA1633" Action="None" /> <!-- File must have header -->
+    <Rule Id="SA1634" Action="Error" /> <!-- File header must show copyright -->
+    <Rule Id="SA1635" Action="Error" /> <!-- File header must have copyright text -->
+    <Rule Id="SA1636" Action="Error" Intentional="true" /> <!-- File header copyright text must match -->
+    <Rule Id="SA1637" Action="Error" /> <!-- File header must contain file name -->
+    <Rule Id="SA1638" Action="Error" /> <!-- File header file name documentation must match file name -->
+    <Rule Id="SA1639" Action="Error" /> <!-- File header must have summary -->
+    <Rule Id="SA1640" Action="Error" /> <!-- File header must have valid company text -->
+    <Rule Id="SA1641" Action="Error" /> <!-- File header company name text must match -->
+    <Rule Id="SA1642" Action="Error" /> <!-- Constructor summary documentation must begin with standard text -->
+    <Rule Id="SA1643" Action="Error" /> <!-- Destructor summary documentation must begin with standard text -->
+    <Rule Id="SA1644" Action="None" Intentional="true" /> <!-- Documentation header must not contain blank lines -->
+    <Rule Id="SA1648" Action="Error" /> <!-- inheritdoc must be used with inheriting class -->
+    <Rule Id="SA1649" Action="Error" /> <!-- File name must match first type name -->
+    <Rule Id="SA1651" Action="Error" /> <!-- Do not use placeholder elements -->
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
This PR implements StyleCop.Analyzers in both projects, and cleans up the existing code to conform to the style settings. Some rules are disabled on a per-file basis to allow compilation in preparation of further cleanup and refactoring.