### PR TITLE
Add binding customization attribute

### DIFF
--- a/AdvanceDLSupport.Tests/IntegrationTests.cs
+++ b/AdvanceDLSupport.Tests/IntegrationTests.cs
@@ -41,5 +41,34 @@ namespace AdvanceDLSupport.Tests
 
 			Assert.Equal(expected, actual);
 		}
+
+		[Property]
+		public void CanCallFunctionWithDifferentEntryPoint(int value, int multiplier)
+		{
+			var strct =  new TestStruct { A = value };
+
+			var expected = value * multiplier;
+			var actual = _fixture.Library.Multiply(ref strct, multiplier);
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Property]
+		public void CanCallFunctionWithDifferentCallingConvention(int value, int other)
+		{
+			var expected = value - other;
+			var actual = _fixture.Library.CDeclSubtract(value, other);
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Property]
+		public void CanCallDuplicateFunction(int value, int other)
+		{
+			var expected = value - other;
+			var actual = _fixture.Library.Subtract(value, other);
+
+			Assert.Equal(expected, actual);
+		}
 	}
 }

--- a/AdvanceDLSupport.Tests/IntegrationTests.cs
+++ b/AdvanceDLSupport.Tests/IntegrationTests.cs
@@ -1,6 +1,3 @@
-using System;
-using AdvancedDLSupport;
-using AdvanceDLSupport.Tests.Interfaces;
 using AdvanceDLSupport.Tests.Structures;
 using FsCheck.Xunit;
 using Xunit;

--- a/AdvanceDLSupport.Tests/Interfaces/ITestLibrary.cs
+++ b/AdvanceDLSupport.Tests/Interfaces/ITestLibrary.cs
@@ -1,4 +1,6 @@
-﻿using AdvanceDLSupport.Tests.Structures;
+﻿using System.Runtime.InteropServices;
+using AdvancedDLSupport.Attributes;
+using AdvanceDLSupport.Tests.Structures;
 
 #pragma warning disable SA1600, CS1591 // Elements should be documented
 
@@ -7,6 +9,16 @@ namespace AdvanceDLSupport.Tests.Interfaces
     public interface ITestLibrary
     {
         int DoStructMath(ref TestStruct struc, int multiplier);
+
+        [NativeFunction("DoStructMath")]
+        int Multiply(ref TestStruct struc, int multiplier);
+
         int Multiply(int value, int multiplier);
+
+        [NativeFunction(CallingConvention = CallingConvention.Cdecl)]
+        int CDeclSubtract(int value, int other);
+
+        [NativeFunction("CDeclSubtract", CallingConvention = CallingConvention.Cdecl)]
+        int Subtract(int value, int other);
     }
 }

--- a/AdvanceDLSupport.Tests/LibraryFixture.cs
+++ b/AdvanceDLSupport.Tests/LibraryFixture.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using AdvancedDLSupport;
 using AdvanceDLSupport.Tests.Interfaces;

--- a/AdvanceDLSupport.Tests/c/src/Test.c
+++ b/AdvanceDLSupport.Tests/c/src/Test.c
@@ -15,3 +15,8 @@ int32_t Multiply(int value, int multiplier)
 {
     return value * multiplier;
 }
+
+__cdecl int32_t CDeclSubtract(int value, int other)
+{
+    return value - other;
+}

--- a/AdvancedDLSupport.Example/Program.cs
+++ b/AdvancedDLSupport.Example/Program.cs
@@ -19,7 +19,7 @@ namespace AdvancedDLSupport.Example
             var field = wrapper.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetField)
             .First
             (
-                f => f.Name == "DoMath_dtm"
+                f => f.Name.StartsWith("DoMath_dtm")
             );
 
             var val = field.GetValue(wrapper);

--- a/AdvancedDLSupport/Attributes/NativeFunctionAttribute.cs
+++ b/AdvancedDLSupport/Attributes/NativeFunctionAttribute.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace AdvancedDLSupport.Attributes
+{
+    /// <summary>
+    /// Holds metadata for native functions.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class NativeFunctionAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets the name of the function's entrypoint.
+        /// </summary>
+        public string Entrypoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function's calling convention.
+        /// </summary>
+        public CallingConvention CallingConvention { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NativeFunctionAttribute"/> class.
+        /// </summary>
+        public NativeFunctionAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NativeFunctionAttribute"/> class.
+        /// </summary>
+        /// <param name="entrypoint">The name of the function's entry point.</param>
+        public NativeFunctionAttribute(string entrypoint)
+        {
+            Entrypoint = entrypoint;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an attribute that can be used to customize the binding of a native function. At present, it implements a way to override the entrypoint, and a way to override the calling convention.